### PR TITLE
[BUGFIX] Fixed issue when payload is empty

### DIFF
--- a/EventListener/ValidationRequestListener.php
+++ b/EventListener/ValidationRequestListener.php
@@ -72,6 +72,10 @@ class ValidationRequestListener
         // https://github.com/sulu/SuluValidationBundle/issues/3
         $dataObject = json_decode(json_encode($data));
 
+        if (!$dataObject) {
+            $dataObject = new \stdClass();
+        }
+
         // Validate data with given schema.
         $validator = new \JsonSchema\Validator();
         $validator->check($dataObject, $schema);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | none |
| Related issues/PRs | none |
| License | MIT |
#### What's in this PR?

When no payload is provided, sulu validation returns 400 with message that an object is expected, but an array was provided.
With this fix, validation returns 400 with all the missing attributes.
